### PR TITLE
Add snippet for anonymous self-executing function

### DIFF
--- a/snippets/function-self-executing-anonymous.cson
+++ b/snippets/function-self-executing-anonymous.cson
@@ -1,0 +1,8 @@
+".source.js":
+  "anonymous self-executing function":
+    "prefix": "asefn"
+    "body": """
+    (function(${2:params}) {
+      ${0:// body...}
+    })(${1:window});
+    """


### PR DESCRIPTION
The prefix 'asefn' is a little long, maybe. 
