### PR TITLE
Add space for anonymous functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ console.warn(${1:obj});
 ### [ae] addEventListener
 
 ```javascript
-${1:document}.addEventListener('${2:event}', function(e) {
+${1:document}.addEventListener('${2:event}', function (e) {
 	${0:// body...}
 });
 ```
@@ -159,7 +159,7 @@ ${1:document}.querySelectorAll('${2:selector}');
 ### [fe] forEach
 
 ```javascript
-${1:myArray}.forEach(function(${2:elem}) {
+${1:myArray}.forEach(function (${2:elem}) {
 	${0:// body...}
 });
 ```
@@ -187,7 +187,7 @@ function ${1:methodName} (${2:arguments}) {
 ### [afn] anonymous function
 
 ```javascript
-function(${1:arguments}) {
+function (${1:arguments}) {
 	${0:// body...}
 }
 ```
@@ -195,7 +195,7 @@ function(${1:arguments}) {
 ### [pr] prototype
 
 ```javascript
-${1:ClassName}.prototype.${2:methodName} = function(${3:arguments}) {
+${1:ClassName}.prototype.${2:methodName} = function (${3:arguments}) {
 	${0:// body...}
 }
 ```
@@ -203,7 +203,7 @@ ${1:ClassName}.prototype.${2:methodName} = function(${3:arguments}) {
 ### [iife] immediately-invoked function expression
 
 ```javascript
-(function(window, document, undefined) {
+(function (window, document, undefined) {
 	${0:// body...}
 })(window, document);
 ```
@@ -223,7 +223,7 @@ ${1:methodName}.apply(${2:context}, [${3:arguments}])
 ### [ofn] function as a property of an object
 
 ```javascript
-${1:functionName}: function(${2:arguments}) {
+${1:functionName}: function (${2:arguments}) {
 	${3:// body...}
 }
 ```
@@ -233,7 +233,7 @@ ${1:functionName}: function(${2:arguments}) {
 ### [si] setInterval
 
 ```javascript
-setInterval(function() {
+setInterval(function () {
 	${0:// body...}
 }, ${1:delay});
 ```
@@ -241,7 +241,7 @@ setInterval(function() {
 ### [st] setTimeout
 
 ```javascript
-setTimeout(function() {
+setTimeout(function () {
 	${0:// body...}
 }, ${1:delay});
 ```
@@ -288,14 +288,14 @@ require('${1:module}');
 ### [desc] describe
 
 ```javascript
-describe('${1:description}', function() {
+describe('${1:description}', function () {
 	${0:// body...}
 });
 ```
 ### [ita] it asynchronous
 
 ```javascript
-it('${1:description}', function(done) {
+it('${1:description}', function (done) {
 	${0:// body...}
 });
 ```
@@ -303,7 +303,7 @@ it('${1:description}', function(done) {
 ### [its] it synchronous
 
 ```javascript
-it('${1:description}', function() {
+it('${1:description}', function () {
 	${0:// body...}
 });
 ```

--- a/snippets/bdd-describe.cson
+++ b/snippets/bdd-describe.cson
@@ -2,7 +2,7 @@
   "describe":
     "prefix": "desc"
     "body": """
-    describe('${1:description}', function() {
+    describe('${1:description}', function () {
       ${0:// body...}
     });
     """

--- a/snippets/bdd-ita.cson
+++ b/snippets/bdd-ita.cson
@@ -2,7 +2,7 @@
   "it asynchronous":
     "prefix": "ita"
     "body": """
-    it('${1:description}', function(done) {
+    it('${1:description}', function (done) {
       ${0:// body...}
     });
     """

--- a/snippets/bdd-its.cson
+++ b/snippets/bdd-its.cson
@@ -2,7 +2,7 @@
   "it synchronous":
     "prefix": "its"
     "body": """
-    it('${1:description}', function() {
+    it('${1:description}', function () {
       ${0:// body...}
     });
     """

--- a/snippets/dom-addEvent.cson
+++ b/snippets/dom-addEvent.cson
@@ -2,7 +2,7 @@
   "addEventListener":
     "prefix": "ae"
     "body": """
-    ${1:document}.addEventListener('${2:event}', function(e) {
+    ${1:document}.addEventListener('${2:event}', function (e) {
       ${0:// body...}
     });
     """

--- a/snippets/for-each.cson
+++ b/snippets/for-each.cson
@@ -2,7 +2,7 @@
   "forEach":
     "prefix": "fe"
     "body": """
-    ${1:myArray}.forEach(function(${2:elem}) {
+    ${1:myArray}.forEach(function (${2:elem}) {
       ${0:// body...}
     });
     """

--- a/snippets/function-anonymous.cson
+++ b/snippets/function-anonymous.cson
@@ -2,7 +2,7 @@
   "anonymous function":
     "prefix": "afn"
     "body": """
-    function(${1:arguments}) {
+    function (${1:arguments}) {
       ${0:// body...}
     }
     """

--- a/snippets/function-iife.cson
+++ b/snippets/function-iife.cson
@@ -2,7 +2,7 @@
   "immediately-invoked function expression":
     "prefix": "iife"
     "body": """
-    (function(window, document, undefined) {
+    (function (window, document, undefined) {
       ${0:// body...}
     })(window, document);
     """

--- a/snippets/function-objectProperty.cson
+++ b/snippets/function-objectProperty.cson
@@ -2,7 +2,7 @@
   "function as a property of an object":
     "prefix": "ofn"
     "body": """
-    ${1:functionName}: function(${2:arguments}) {
+    ${1:functionName}: function (${2:arguments}) {
       ${3:// body...}
     }
     """

--- a/snippets/function-prototype.cson
+++ b/snippets/function-prototype.cson
@@ -2,7 +2,7 @@
   "prototype":
     "prefix": "pr"
     "body": """
-    ${1:ClassName}.prototype.${2:methodName} = function(${3:arguments}) {
+    ${1:ClassName}.prototype.${2:methodName} = function (${3:arguments}) {
       ${0:// body...}
     }
     """

--- a/snippets/timer-setInterval.cson
+++ b/snippets/timer-setInterval.cson
@@ -2,7 +2,7 @@
   "setInterval":
     "prefix": "si"
     "body": """
-    setInterval(function() {
+    setInterval(function () {
       ${0:// body...}
     }, ${1:delay});
     """

--- a/snippets/timer-setTimeout.cson
+++ b/snippets/timer-setTimeout.cson
@@ -2,7 +2,7 @@
   "setTimeout":
     "prefix": "st"
     "body": """
-    setTimeout(function() {
+    setTimeout(function () {
       ${0:// body...}
     }, ${1:delay});
     """


### PR DESCRIPTION
Based on Crockford's JS conventions, [anonymous functions should have one space between the word function and the ( (left parenthesis).](http://javascript.crockford.com/code.html#function)