### PR TITLE
Suggestions for "for in" loop

### DIFF
--- a/snippets/for-in.cson
+++ b/snippets/for-in.cson
@@ -2,9 +2,8 @@
   "for in":
     "prefix": "fi"
     "body": """
-    for (${1:prop} in ${2:obj}) {
-    \tif (${2:obj}.hasOwnProperty(${1:prop})) {
-    \t\t${0:// body...}
-    \t}
+    for (${2:prop} in ${1:obj}) {
+    \tif (!${1:obj}.hasOwnProperty(${2:prop})) { continue; }
+    \t${0:// body...}
     }
     """


### PR DESCRIPTION
Should default to logical naming of object before object property
Reduce indenting and cognitive overhead by common use case of skipping loop if native property